### PR TITLE
更改為 vue v3.2.37 版本

### DIFF
--- a/Scheduler/Views/Home/Index.cshtml
+++ b/Scheduler/Views/Home/Index.cshtml
@@ -62,14 +62,15 @@
 <script>
 
 
-    var app = new Vue({
-        el: '#app',
-        data: {
-            connection: null,
-            jobs: [],
-            counter: 0,
-            time: '',
-            timeInterval: null
+ var app = Vue.createApp({
+        data() {
+            return {
+                connection: null,
+                jobs: [],
+                counter: 0,
+                time: '',
+                timeInterval: null
+            }
         },
         async mounted() {
 
@@ -139,7 +140,6 @@
                 return YYYY + "-" + MM + "-" + DD + " " + hh + ":" + mm + ":" + ss;
             }
         }
-    });
-
+    }).mount('#app');
 
 </script>


### PR DESCRIPTION
### 主因 :
[Vue Cdn](https://unpkg.com/vue) 已經到 v3.2.37，目前直接使用會無法正常執行，稍微調整 js 使用方式。

---
### 備註 : 
如果不需要這個請忽略我。 